### PR TITLE
refactor: exports del cliente y servidor más legibles

### DIFF
--- a/client/Exports.lua
+++ b/client/Exports.lua
@@ -1,305 +1,151 @@
-local L0_1, L1_1, L2_1
-L0_1 = exports
-L1_1 = "GetCurrentPropertyId"
-function L2_1()
-  local L0_2, L1_2, L2_2, L3_2, L4_2, L5_2, L6_2, L7_2, L8_2, L9_2
-  L0_2 = PlayerData
-  L0_2 = L0_2.currentProperty
-  if L0_2 then
-    L0_2 = PlayerData
-    L0_2 = L0_2.currentProperty
-    L0_2 = L0_2.id
-    return L0_2
-  else
-    L0_2 = PlayerData
-    L0_2 = L0_2.insideYards
-    if L0_2 then
-      L1_2 = next
-      L2_2 = L0_2
-      L1_2 = L1_2(L2_2)
-      if L1_2 then
-        L1_2 = {}
-        L2_2 = pairs
-        L3_2 = L0_2
-        L2_2, L3_2, L4_2, L5_2 = L2_2(L3_2)
-        for L6_2, L7_2 in L2_2, L3_2, L4_2, L5_2 do
-          if L7_2 then
-            L8_2 = #L1_2
-            L8_2 = L8_2 + 1
-            L9_2 = {}
-            L9_2.id = L6_2
-            L1_2[L8_2] = L9_2
-          end
-        end
-        L2_2 = L1_2[1]
-        L2_2 = L2_2.id
-        return L2_2
-      end
+-- Human-readable exports for property management
+
+-- Return the ID of the property the player is currently in, or nil
+exports("GetCurrentPropertyId", function()
+    local currentProperty = PlayerData.currentProperty
+    if currentProperty then
+        return currentProperty.id
     end
-  end
-  L0_2 = nil
-  return L0_2
-end
-L0_1(L1_1, L2_1)
-L0_1 = exports
-L1_1 = "GetCurrentProperty"
-function L2_1()
-  local L0_2, L1_2, L2_2
-  L0_2 = PlayerData
-  L0_2 = L0_2.currentProperty
-  if L0_2 then
-    L0_2 = {}
-    L1_2 = PlayerData
-    L1_2 = L1_2.currentProperty
-    L1_2 = L1_2.id
-    L0_2.id = L1_2
-    L1_2 = PlayerData
-    L1_2 = L1_2.currentProperty
-    L1_2 = L1_2.owner
-    L0_2.owner = L1_2
-    L1_2 = PlayerData
-    L1_2 = L1_2.currentProperty
-    L1_2 = L1_2.label
-    L0_2.label = L1_2
-    L1_2 = PlayerData
-    L1_2 = L1_2.currentProperty
-    L1_2 = L1_2.price
-    L0_2.price = L1_2
-    L1_2 = PlayerData
-    L1_2 = L1_2.currentProperty
-    L1_2 = L1_2.type
-    L0_2.type = L1_2
-    L1_2 = PlayerData
-    L1_2 = L1_2.currentProperty
-    L2_2 = L1_2
-    L1_2 = L1_2.getDoorLockedState
-    L1_2 = L1_2(L2_2)
-    L0_2.doorLocked = L1_2
-    L1_2 = PlayerData
-    L1_2 = L1_2.currentProperty
-    L1_2 = L1_2.keyHolders
-    L0_2.keyHolders = L1_2
-    function L1_2(A0_3)
-      local L1_3, L2_3, L3_3
-      L1_3 = PlayerData
-      L1_3 = L1_3.currentProperty
-      L2_3 = L1_3
-      L1_3 = L1_3.hasKey
-      L3_3 = A0_3
-      return L1_3(L2_3, L3_3)
-    end
-    L0_2.hasKey = L1_2
-    function L1_2()
-      local L0_3, L1_3
-      L0_3 = PlayerData
-      L0_3 = L0_3.currentProperty
-      L1_3 = L0_3
-      L0_3 = L0_3.isOwner
-      return L0_3(L1_3)
-    end
-    L0_2.isOwner = L1_2
-    if L0_2 then
-      goto lbl_43
-    end
-  end
-  L0_2 = nil
-  ::lbl_43::
-  return L0_2
-end
-L0_1(L1_1, L2_1)
-L0_1 = exports
-L1_1 = "IsPointInsideProperty"
-L2_1 = IsPointInside
-L0_1(L1_1, L2_1)
-L0_1 = exports
-L1_1 = "OpenPropertyMenu"
-L2_1 = OpenPropertyMenu
-L0_1(L1_1, L2_1)
-L0_1 = exports
-L1_1 = "RemoveKey"
-function L2_1(A0_2, A1_2)
-  local L2_2, L3_2, L4_2, L5_2
-  L2_2 = PropertyManager
-  L3_2 = L2_2
-  L2_2 = L2_2.getPropertyById
-  L4_2 = A0_2
-  L2_2 = L2_2(L3_2, L4_2)
-  if not L2_2 then
-    L3_2 = false
-    return L3_2
-  end
-  L4_2 = L2_2
-  L3_2 = L2_2.removeKeyHolder
-  L5_2 = A1_2
-  return L3_2(L4_2, L5_2)
-end
-L0_1(L1_1, L2_1)
-L0_1 = exports
-L1_1 = "AddKey"
-function L2_1(A0_2, A1_2)
-  local L2_2, L3_2, L4_2, L5_2
-  L2_2 = PropertyManager
-  L3_2 = L2_2
-  L2_2 = L2_2.getPropertyById
-  L4_2 = A0_2
-  L2_2 = L2_2(L3_2, L4_2)
-  if not L2_2 then
-    L3_2 = false
-    return L3_2
-  end
-  L4_2 = L2_2
-  L3_2 = L2_2.addKeyHolder
-  L5_2 = A1_2
-  return L3_2(L4_2, L5_2)
-end
-L0_1(L1_1, L2_1)
-L0_1 = exports
-L1_1 = "SetWaypointToProperty"
-function L2_1(A0_2)
-  local L1_2, L2_2, L3_2
-  L1_2 = PropertyManager
-  L2_2 = L1_2
-  L1_2 = L1_2.getPropertyById
-  L3_2 = A0_2
-  L1_2 = L1_2(L2_2, L3_2)
-  if not L1_2 then
-    L2_2 = false
-    return L2_2
-  end
-  L3_2 = L1_2
-  L2_2 = L1_2.setWaypoint
-  L2_2(L3_2)
-end
-L0_1(L1_1, L2_1)
-L0_1 = exports
-L1_1 = "GetAllProperties"
-function L2_1(A0_2)
-  local L1_2, L2_2, L3_2, L4_2, L5_2, L6_2, L7_2, L8_2, L9_2, L10_2, L11_2, L12_2, L13_2
-  L1_2 = {}
-  L2_2 = PlayerData
-  L2_2 = L2_2.job
-  L2_2 = L2_2.name
-  if "society" == A0_2 then
-    L3_2 = PlayerData
-    L3_2 = L3_2.job
-    L3_2 = L3_2.name
-    if L3_2 then
-      goto lbl_15
-    end
-  end
-  L3_2 = PlayerData
-  L3_2 = L3_2.identifier
-  ::lbl_15::
-  L4_2 = pairs
-  L5_2 = PropertyManager
-  L5_2 = L5_2.properties
-  L4_2, L5_2, L6_2, L7_2 = L4_2(L5_2)
-  for L8_2, L9_2 in L4_2, L5_2, L6_2, L7_2 do
-    if "both" == A0_2 then
-      L10_2 = L9_2.owner
-      if L10_2 == L3_2 then
-        goto lbl_34
-      end
-      L10_2 = L9_2.owner
-      if L10_2 == L2_2 then
-        goto lbl_34
-      end
-    end
-    L10_2 = L9_2.owner
-    if L10_2 == L3_2 then
-      L10_2 = L9_2.ownerType
-      ::lbl_34::
-      if L10_2 == A0_2 then
-        L10_2 = #L1_2
-        L10_2 = L10_2 + 1
-        L11_2 = {}
-        L12_2 = L9_2.id
-        L11_2.id = L12_2
-        L12_2 = L9_2.label
-        L11_2.label = L12_2
-        L12_2 = L9_2.price
-        L11_2.price = L12_2
-        L12_2 = L9_2.type
-        L11_2.type = L12_2
-        L13_2 = L9_2
-        L12_2 = L9_2.getDoorLockedState
-        L12_2 = L12_2(L13_2)
-        L11_2.doorLocked = L12_2
-        L12_2 = L9_2.keyHolders
-        L11_2.keyHolders = L12_2
-        L1_2[L10_2] = L11_2
-      end
-    end
-  end
-  return L1_2
-end
-L0_1(L1_1, L2_1)
-L0_1 = exports
-L1_1 = "GetKeyHolders"
-function L2_1(A0_2)
-  local L1_2, L2_2, L3_2
-  L1_2 = PropertyManager
-  L2_2 = L1_2
-  L1_2 = L1_2.getPropertyById
-  L3_2 = A0_2
-  L1_2 = L1_2(L2_2, L3_2)
-  if not L1_2 then
-    return
-  end
-  L2_2 = L1_2.keyHolders
-  return L2_2
-end
-L0_1(L1_1, L2_1)
-L0_1 = exports
-L1_1 = "GetClosestProperty"
-function L2_1()
-  local L0_2, L1_2, L2_2, L3_2, L4_2, L5_2, L6_2, L7_2, L8_2, L9_2, L10_2, L11_2
-  L0_2 = PlayerData
-  L0_2 = L0_2.currentProperty
-  if L0_2 then
-    return L0_2
-  end
-  L1_2 = PlayerData
-  L1_2 = L1_2.insideYards
-  if L1_2 then
-    L2_2 = next
-    L3_2 = L1_2
-    L2_2 = L2_2(L3_2)
-    if L2_2 then
-      L2_2 = pairs
-      L3_2 = L1_2
-      L2_2, L3_2, L4_2, L5_2 = L2_2(L3_2)
-      for L6_2, L7_2 in L2_2, L3_2, L4_2, L5_2 do
-        if L7_2 then
-          if not L0_2 then
-            L8_2 = LoadedProperties
-            L0_2 = L8_2[L6_2]
-          else
-            L8_2 = GetEntityCoords
-            L9_2 = cache
-            L9_2 = L9_2.ped
-            L8_2 = L8_2(L9_2)
-            L9_2 = L0_2.metadata
-            L9_2 = L9_2.managePoint
-            L9_2 = L9_2 - L8_2
-            L9_2 = #L9_2
-            L10_2 = LoadedProperties
-            L10_2 = L10_2[L6_2]
-            L10_2 = L10_2.metadata
-            L10_2 = L10_2.managePoint
-            L10_2 = L10_2 - L8_2
-            L10_2 = #L10_2
-            if L9_2 > L10_2 then
-              L11_2 = LoadedProperties
-              L0_2 = L11_2[L6_2]
+
+    local insideYards = PlayerData.insideYards
+    if insideYards then
+        for propertyId, isInside in pairs(insideYards) do
+            if isInside then
+                return propertyId
             end
-          end
         end
-      end
-      return L0_2
     end
-  end
-  L2_2 = nil
-  return L2_2
-end
-L0_1(L1_1, L2_1)
+
+    return nil
+end)
+
+-- Return a table with information about the property the player is currently in
+exports("GetCurrentProperty", function()
+    local current = PlayerData.currentProperty
+    if not current then
+        return nil
+    end
+
+    local propertyInfo = {
+        id = current.id,
+        owner = current.owner,
+        label = current.label,
+        price = current.price,
+        type = current.type,
+        doorLocked = current:getDoorLockedState(),
+        keyHolders = current.keyHolders
+    }
+
+    function propertyInfo.hasKey(identifier)
+        return current:hasKey(identifier)
+    end
+
+    function propertyInfo.isOwner()
+        return current:isOwner()
+    end
+
+    return propertyInfo
+end)
+
+exports("IsPointInsideProperty", IsPointInside)
+exports("OpenPropertyMenu", OpenPropertyMenu)
+
+-- Remove a key holder from a property
+exports("RemoveKey", function(propertyId, identifier)
+    local property = PropertyManager:getPropertyById(propertyId)
+    if not property then
+        return false
+    end
+    return property:removeKeyHolder(identifier)
+end)
+
+-- Add a key holder to a property
+exports("AddKey", function(propertyId, identifier)
+    local property = PropertyManager:getPropertyById(propertyId)
+    if not property then
+        return false
+    end
+    return property:addKeyHolder(identifier)
+end)
+
+-- Set a waypoint to a property's location
+exports("SetWaypointToProperty", function(propertyId)
+    local property = PropertyManager:getPropertyById(propertyId)
+    if not property then
+        return false
+    end
+    property:setWaypoint()
+end)
+
+-- Get all properties owned by the player or their job/society
+exports("GetAllProperties", function(ownerType)
+    local results = {}
+    local jobName = PlayerData.job.name
+    local identifier = PlayerData.identifier
+
+    for _, property in pairs(PropertyManager.properties) do
+        local ownedByPlayer = property.owner == identifier
+        local ownedByJob = property.owner == jobName
+
+        local allowed
+        if ownerType == "both" then
+            allowed = ownedByPlayer or ownedByJob
+        else
+            allowed = ownedByPlayer
+        end
+
+        if allowed and property.ownerType == ownerType then
+            results[#results + 1] = {
+                id = property.id,
+                label = property.label,
+                price = property.price,
+                type = property.type,
+                doorLocked = property:getDoorLockedState(),
+                keyHolders = property.keyHolders
+            }
+        end
+    end
+
+    return results
+end)
+
+-- Return the key holders of a property
+exports("GetKeyHolders", function(propertyId)
+    local property = PropertyManager:getPropertyById(propertyId)
+    if not property then return end
+    return property.keyHolders
+end)
+
+-- Find the closest property to the player when inside a yard
+exports("GetClosestProperty", function()
+    local current = PlayerData.currentProperty
+    if current then
+        return current
+    end
+
+    local insideYards = PlayerData.insideYards
+    if not insideYards then
+        return nil
+    end
+
+    local playerCoords = GetEntityCoords(cache.ped)
+    local closestProperty
+    local closestDistance
+
+    for propertyId, isInside in pairs(insideYards) do
+        if isInside then
+            local property = LoadedProperties[propertyId]
+            if property then
+                local managePoint = property.metadata.managePoint
+                local distance = #(managePoint - playerCoords)
+                if not closestDistance or distance < closestDistance then
+                    closestDistance = distance
+                    closestProperty = property
+                end
+            end
+        end
+    end
+
+    return closestProperty
+end)
+

--- a/server/Exports.lua
+++ b/server/Exports.lua
@@ -1,4 +1,37 @@
-local L0_1, L1_1, L2_1
-L0_1 = exports
-L1_1 = "GetAllProperties"
-function L2_1(A0_2, A1_2, A2_2)
+-- Human-readable exports for server-side property interactions
+
+-- Return simplified information about all loaded properties
+exports('GetAllProperties', function()
+    local properties = {}
+
+    for id, property in pairs(LoadedProperties) do
+        local data = property.propertyData
+        properties[#properties + 1] = {
+            id = id,
+            owner = data.owner,
+            ownerType = data.ownerType,
+            label = data.label,
+            price = data.price,
+            rentPrice = data.rentPrice,
+            type = data.type,
+            doorLocked = data.doorLocked,
+            keyHolders = data.keyHolders
+        }
+    end
+
+    return properties
+end)
+
+-- Return the full ServerProperty object for a given property ID
+exports('GetProperty', function(propertyId)
+    return LoadedProperties[tonumber(propertyId)]
+end)
+
+-- Return the key holders for a given property ID
+exports('GetKeyHolders', function(propertyId)
+    local property = LoadedProperties[tonumber(propertyId)]
+    if not property then
+        return nil
+    end
+    return property.propertyData.keyHolders
+end)


### PR DESCRIPTION
## Summary
- reescritura del archivo `client/Exports.lua` con nombres descriptivos y comentarios
- reescritura del archivo `server/Exports.lua` con funciones claras para propiedades

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9be3fd0108329888aa07eafd0e142